### PR TITLE
Comparator is now case insensitive

### DIFF
--- a/NaturalOrderComparator.java
+++ b/NaturalOrderComparator.java
@@ -127,7 +127,7 @@ public class NaturalOrderComparator implements Comparator
     }
 
     static char charAt(String s, int i) {
-        return i >= s.length() ? 0 : s.charAt(i);
+        return i >= s.length() ? 0 : Character.toUpperCase(s.charAt(i));
     }
 
     public static void main(String[] args)
@@ -135,7 +135,7 @@ public class NaturalOrderComparator implements Comparator
         String[] strings = new String[] { "1-2", "1-02", "1-20", "10-20", "fred", "jane", "pic01",
             "pic2", "pic02", "pic02a", "pic3", "pic4", "pic 4 else", "pic 5", "pic05", "pic 5",
             "pic 5 something", "pic 6", "pic   7", "pic100", "pic100a", "pic120", "pic121",
-            "pic02000", "tom", "x2-g8", "x2-y7", "x2-y08", "x8-y8" };
+            "pic02000", "tom", "x2-g8", "x2-y7", "x2-y08", "x8-y8", "politely", "POLITELY SCREAMING" };
 
         List orig = Arrays.asList(strings);
 


### PR DESCRIPTION
Output with case sensitivity (old behavior):

> Sorted: [1-2, 1-02, 1-20, 10-20, POLITELY SCREAMING, fred, jane, pic01, pic02, pic2, pic02a, pic3, pic4, pic 4 else, pic 5, pic 5, pic05, pic 5 something, pic 6, pic   7, pic100, pic100a, pic120, pic121, pic02000, politely, tom, x2-g8, x2-y7, x2-y08, x8-y8]

output after this change:

> Sorted: [1-2, 1-02, 1-20, 10-20, fred, jane, pic01, pic2, pic02, pic02a, pic3, pic4, pic 4 else, pic 5, pic05, pic 5, pic 5 something, pic 6, pic   7, pic100, pic100a, pic120, pic121, pic02000, politely, POLITELY SCREAMING, tom, x2-g8, x2-y7, x2-y08, x8-y8]

The usecase for natural ordering is most often to produce an ordering which a human "expects". Case insensitivity might also be expected so I added it here. One could maybe discuss whether the case should be used again when breaking ties (which this PR does not).